### PR TITLE
un-inline all the things

### DIFF
--- a/ipvisualizer/client/constants.h
+++ b/ipvisualizer/client/constants.h
@@ -43,3 +43,5 @@ extern unsigned int b_mask_rev;
 /* call this function to initialize these variables */
 void initunconstants();
 void setnet(unsigned int base, unsigned int mask);
+void screensize(int w, int h);
+

--- a/ipvisualizer/client/display.c
+++ b/ipvisualizer/client/display.c
@@ -123,7 +123,7 @@ void keyup(unsigned char k, int x, int y);
 unsigned short fwd_netblock(unsigned short);
 unsigned short rev_netblock(unsigned short);
 void update_menubar();
-inline unsigned short mappixel(unsigned short ip);
+unsigned short mappixel(unsigned short ip);
 void sdl_eventloop();
 void printdisplay(const char* s, unsigned short ip);
 void allocatescreen();
@@ -662,7 +662,7 @@ void keyup(unsigned char k, int x, int y)
  * recieves:	ip
  * returns:		pixel
  */
-inline unsigned short mappixel(unsigned short ip)
+unsigned short mappixel(unsigned short ip)
 {
 	switch (mapping) {
 	case 0: /* linear mapping */
@@ -678,7 +678,7 @@ inline unsigned short mappixel(unsigned short ip)
 	mapping = 0;
 	return ip;
 }
-inline unsigned short unmappixel(unsigned short ip)
+unsigned short unmappixel(unsigned short ip)
 {
 	switch (mapping) {
 	case 0: /*linear*/
@@ -774,7 +774,7 @@ void reshape (int w, int h)
  * purpose:		to draw a line to the left of a pixel
  * recieves:	the x and y coords, and the blue, green and red components
  */
-inline void lineleft(int i, int j, unsigned char b, unsigned char g, unsigned char r)
+void lineleft(int i, int j, unsigned char b, unsigned char g, unsigned char r)
 {
 	int k;
 	for (k = 0; k < BLOCKHEIGHT; k++) 
@@ -793,7 +793,7 @@ inline void lineleft(int i, int j, unsigned char b, unsigned char g, unsigned ch
  * purpose:     to draw a line above a pixel
  * recieves:    the x and y coords, and the blue, green and red components
  */
-inline void lineup(int i, int j, unsigned char b, unsigned char g, unsigned char r)
+void lineup(int i, int j, unsigned char b, unsigned char g, unsigned char r)
 {
 	int k;
 	for (k = 0; k < BLOCKWIDTH; k++) 
@@ -963,7 +963,7 @@ int idle()
 	return 0;
 }
 
-inline void renderstring(const char* s)
+void renderstring(const char* s)
 {
 /*	while (*s)
 		glutBitmapCharacter(GLUT_BITMAP_8_BY_13, *(s++)); */

--- a/ipvisualizer/server/flowserv.c
+++ b/ipvisualizer/server/flowserv.c
@@ -88,7 +88,7 @@ void delclient(unsigned int ip, unsigned short port);
  * purpose:		to send some data to all of our clients
  * recieves:	a pointer to the data, and its length
  */
-inline void sendclients(void* data, int dlen)
+void sendclients(void* data, int dlen)
 {
 	int i;
 	struct sockaddr_in sin;
@@ -119,7 +119,7 @@ inline void sendclients(void* data, int dlen)
  * purpose:	to flush data to a client socket
  * recieves:	a client struct
  */
-inline void flushbuffer() {
+void flushbuffer() {
 	sendclients(&flowbuffer, flowpacketsize(buffer) + SIZEOF_PACKETHEADER);
 	lastupdate = gettime();
 	buffer->count = 0;

--- a/ipvisualizer/server/mygettime.h
+++ b/ipvisualizer/server/mygettime.h
@@ -30,7 +30,7 @@
  * purpose: to return the time in milliseconds since the unix epoch
  * returns: didn't you read the purpose?
  */
-inline unsigned long long gettime() {
+unsigned long long gettime() {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (tv.tv_sec * 1000 + tv.tv_usec / 1000);

--- a/ipvisualizer/shared/flowdata.h
+++ b/ipvisualizer/shared/flowdata.h
@@ -173,10 +173,10 @@ typedef struct t_binaryrule {
 } binaryrule;
 
 
-inline int flowpacketsize(struct flowpacket* f);
-inline int fwflowpacketsize(struct fwflowpacket* f);
-inline int subnetpacketsize(struct subnetpacket* s);
-inline void readrulepacket(void* buffer, struct fwrulepacket* r);
+int flowpacketsize(struct flowpacket* f);
+int fwflowpacketsize(struct fwflowpacket* f);
+int subnetpacketsize(struct subnetpacket* s);
+void readrulepacket(void* buffer, struct fwrulepacket* r);
 int writerulepacket(void* buffer, unsigned short num, unsigned short max, const char* string);
 
 #endif /* !FLOWDATA_H */


### PR DESCRIPTION
Since we are compiling with -O2 by default, most compilers should be smarter than we are on whether or not to inline a function.  This was causing trouble with the latest version of gcc which now defaults to -std=gnu11 instead of gnu89.
