### PR TITLE
Fix lcurl

### DIFF
--- a/ipvisualizer/aclocal.m4
+++ b/ipvisualizer/aclocal.m4
@@ -1042,35 +1042,6 @@ else
 fi
 ])
 
-#  -*- Autoconf -*-
-# Obsolete and "removed" macros, that must however still report explicit
-# error messages when used, to smooth transition.
-#
-# Copyright (C) 1996-2014 Free Software Foundation, Inc.
-#
-# This file is free software; the Free Software Foundation
-# gives unlimited permission to copy and/or distribute it,
-# with or without modifications, as long as this notice is preserved.
-
-AC_DEFUN([AM_CONFIG_HEADER],
-[AC_DIAGNOSE([obsolete],
-['$0': this macro is obsolete.
-You should use the 'AC][_CONFIG_HEADERS' macro instead.])dnl
-AC_CONFIG_HEADERS($@)])
-
-AC_DEFUN([AM_PROG_CC_STDC],
-[AC_PROG_CC
-am_cv_prog_cc_stdc=$ac_cv_prog_cc_stdc
-AC_DIAGNOSE([obsolete],
-['$0': this macro is obsolete.
-You should simply use the 'AC][_PROG_CC' macro instead.
-Also, your code should no longer depend upon 'am_cv_prog_cc_stdc',
-but upon 'ac_cv_prog_cc_stdc'.])])
-
-AC_DEFUN([AM_C_PROTOTYPES],
-         [AC_FATAL([automatic de-ANSI-fication support has been removed])])
-AU_DEFUN([fp_C_PROTOTYPES], [AM_C_PROTOTYPES])
-
 # Helper functions for option handling.                     -*- Autoconf -*-
 
 # Copyright (C) 2001-2014 Free Software Foundation, Inc.

--- a/ipvisualizer/configure
+++ b/ipvisualizer/configure
@@ -5949,6 +5949,7 @@ DEFS=-DHAVE_CONFIG_H
 
 ac_libobjs=
 ac_ltlibobjs=
+U=
 for ac_i in : $LIBOBJS; do test "x$ac_i" = x: && continue
   # 1. Remove the extension, and $U if already installed.
   ac_script='s/\$U\././;s/\.o$//;s/\.obj$//'

--- a/ipvisualizer/configure.ac
+++ b/ipvisualizer/configure.ac
@@ -3,11 +3,11 @@
 
 AUTOMAKE_OPTIONS=subdir-objects
 
-AC_PREREQ(2.61)
-AC_INIT(IPVISUALIZER, 0.4.3, esk-ipvisualizer@esk.cs.usu.edu)
+AC_PREREQ([2.69])
+AC_INIT([IPVISUALIZER],[0.4.3],[esk-ipvisualizer@esk.cs.usu.edu])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([client/constants.h])
-AM_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 AC_ARG_ENABLE([ffmpeg],
 	      AS_HELP_STRING([--enable-ffmpeg], [use ffmpeg libraries to create .avi videos of visualized data])

--- a/ipvisualizer/server/Makefile.am
+++ b/ipvisualizer/server/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS=subdir-objects
 
 ipvisualizer_flowservprgdir=$(prefix)/bin/
 
-ipvisualizer_flowserv_LDFLAGS = ${pcap_LIBS} ${LIBCURL}
+ipvisualizer_flowserv_LDADD = ${pcap_LIBS} ${LIBCURL}
 ipvisualizer_flowserv_CFLAGS = ${pcap_CFLAGS} ${LIBCURL_CPPFLAGS}
 
 ipvisualizer_flowservprg_PROGRAMS=ipvisualizer_flowserv

--- a/ipvisualizer/server/Makefile.in
+++ b/ipvisualizer/server/Makefile.in
@@ -109,9 +109,10 @@ am_ipvisualizer_flowserv_OBJECTS =  \
 	../shared/ipvisualizer_flowserv-flowdata.$(OBJEXT) \
 	../shared/ipvisualizer_flowserv-config.$(OBJEXT)
 ipvisualizer_flowserv_OBJECTS = $(am_ipvisualizer_flowserv_OBJECTS)
-ipvisualizer_flowserv_LDADD = $(LDADD)
+am__DEPENDENCIES_1 =
+ipvisualizer_flowserv_DEPENDENCIES = $(am__DEPENDENCIES_1)
 ipvisualizer_flowserv_LINK = $(CCLD) $(ipvisualizer_flowserv_CFLAGS) \
-	$(CFLAGS) $(ipvisualizer_flowserv_LDFLAGS) $(LDFLAGS) -o $@
+	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -266,7 +267,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = subdir-objects
 ipvisualizer_flowservprgdir = $(prefix)/bin/
-ipvisualizer_flowserv_LDFLAGS = ${pcap_LIBS} ${LIBCURL}
+ipvisualizer_flowserv_LDADD = ${pcap_LIBS} ${LIBCURL}
 ipvisualizer_flowserv_CFLAGS = ${pcap_CFLAGS} ${LIBCURL_CPPFLAGS}
 ipvisualizer_flowserv_SOURCES = flowserv.c fwrules.c globals.c sockutils.c subnets.c ../shared/flowdata.c ../shared/config.c fwrules.h globals.h mygettime.h sockutils.h structs.h subnets.h ../shared/config.h ../shared/flowdata.h
 all: all-am


### PR DESCRIPTION
Use _LDADD instead of _LDFLAGS to specify -lcurl (fixes link errors on ubuntu).
